### PR TITLE
Fix link and Android multiple spinner issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ React native port of [SpinKit](http://tobiasahlin.com/spinkit/).
 
 `npm install react-native-spinkit@latest --save`
 
-##### Link the library automatically using [RNPM](https://github.com/rnpm/rnpm)
+##### Automatically link the library
+`react-native link`
+
+> For RN projects < 0.29 link the library automatically using [RNPM](https://github.com/rnpm/rnpm)
 `rnpm link react-native-spinkit`
 
 ##### Manual linking - IOS

--- a/android/src/main/java/com/react/rnspinkit/RNSpinkit.java
+++ b/android/src/main/java/com/react/rnspinkit/RNSpinkit.java
@@ -1,32 +1,18 @@
 package com.react.rnspinkit;
 
 
-import android.content.res.TypedArray;
 import android.graphics.Color;
-import android.graphics.Rect;
-import android.graphics.drawable.Drawable;
-import android.graphics.drawable.RotateDrawable;
 import android.support.annotation.Nullable;
 import android.util.Log;
-import android.view.ContextThemeWrapper;
-import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.FrameLayout;
-import android.widget.LinearLayout;
-import android.widget.ListView;
-import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 
-import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.SimpleViewManager;
-import com.facebook.react.*;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.ViewManager;
-import com.github.ybq.android.spinkit.SpinKitView;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.views.view.ReactViewGroup;
+import com.github.ybq.android.spinkit.SpinKitView;
 import com.github.ybq.android.spinkit.sprite.Sprite;
 import com.github.ybq.android.spinkit.style.ChasingDots;
 import com.github.ybq.android.spinkit.style.Circle;
@@ -40,13 +26,17 @@ import com.github.ybq.android.spinkit.style.ThreeBounce;
 import com.github.ybq.android.spinkit.style.WanderingCubes;
 import com.github.ybq.android.spinkit.style.Wave;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 /**
  * Created by suzuri04x2 on 2016/5/10.
  */
-public class RNSpinkit extends SimpleViewManager<SpinKitView> {
+public class RNSpinkit extends SimpleViewManager<RNSpinkitView> {
 
     ReactApplicationContext mContext;
-    Sprite mSprite = getSprite("");
+
     double mSize = 48;
 
     public RNSpinkit(ReactApplicationContext reactContext) {
@@ -59,12 +49,12 @@ public class RNSpinkit extends SimpleViewManager<SpinKitView> {
     }
 
     @Override
-    protected SpinKitView createViewInstance(ThemedReactContext reactContext) {
-        return new SpinKitView(reactContext);
+    protected RNSpinkitView createViewInstance(ThemedReactContext reactContext) {
+        return new RNSpinkitView(reactContext);
     }
 
     @ReactProp(name = "isVisible")
-    public void setIsVisible(SpinKitView view, @Nullable Boolean visible) {
+    public void setIsVisible(RNSpinkitView view, @Nullable Boolean visible) {
         if(visible)
             view.setVisibility(View.VISIBLE);
         else
@@ -72,66 +62,19 @@ public class RNSpinkit extends SimpleViewManager<SpinKitView> {
     }
 
     @ReactProp(name = "color")
-    public void setColor(SpinKitView view, @Nullable String color) {
-        try {
-            mSprite.setColor(Color.parseColor(color));
-        view.setIndeterminateDrawable(mSprite);
-        } catch(Exception err) {
-            Log.e("RNSpinkit-Err", err.toString() + "when set prop color to " + color);
-        }
+    public void setColor(RNSpinkitView view, @Nullable String color) {
+        view.setSpriteColor(color);
     }
 
     @ReactProp(name = "size")
-    public void setSize(SpinKitView view, @Nullable double size) {
-        mSize = size;
-        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        view.setLayoutParams(params);
+    public void setSize(RNSpinkitView view, @Nullable double size) {
+        view.setSpriteSize(size);
     }
 
     @ReactProp(name = "type")
-    public void setType(SpinKitView view, @Nullable String spinnerType) {
-        Sprite sprite = getSprite(spinnerType);
-        sprite.setColor(mSprite.getColor());
-        mSprite = sprite;
-        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        view.setLayoutParams(params);
-        view.setIndeterminateDrawable(sprite);
-    }
+    public void setType(RNSpinkitView view, @Nullable String spinnerType) {
+        view.setSpriteType(spinnerType);
 
-    private Sprite getSprite(String spinnerType) {
-        switch (spinnerType) {
-            case "Bounce" :
-                return new DoubleBounce();
-            case "Wave" :
-                return new Wave();
-            case "RotatingPlane" :
-                return new RotatingPlane();
-            case "WanderingCubes":
-                return new WanderingCubes();
-            case "9CubeGrid":
-                return new CubeGrid();
-            case "FadingCircleAlt" :
-                return new FadingCircle();
-            case "Pulse" :
-                return new Pulse();
-            case "ChasingDots":
-                // Add scale factor to prevent clipping
-                Sprite d = new ChasingDots();
-                d.setScale(0.85f);
-                return d;
-            case "ThreeBounce":
-                return new ThreeBounce();
-            case "Circle":
-                return new Circle();
-            case "FoldingCube":
-                // Add scale factor to prevent clipping
-                Sprite sprite = new FoldingCube();
-                sprite.setScale(0.70f);
-                return sprite;
-            default :
-                break;
-        }
-        return new RotatingPlane();
     }
 
 }

--- a/android/src/main/java/com/react/rnspinkit/RNSpinkitView.java
+++ b/android/src/main/java/com/react/rnspinkit/RNSpinkitView.java
@@ -1,0 +1,99 @@
+package com.react.rnspinkit;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.util.Log;
+import android.view.ViewGroup;
+import android.widget.RelativeLayout;
+
+import com.github.ybq.android.spinkit.SpinKitView;
+import com.github.ybq.android.spinkit.sprite.Sprite;
+import com.github.ybq.android.spinkit.style.ChasingDots;
+import com.github.ybq.android.spinkit.style.Circle;
+import com.github.ybq.android.spinkit.style.CubeGrid;
+import com.github.ybq.android.spinkit.style.DoubleBounce;
+import com.github.ybq.android.spinkit.style.FadingCircle;
+import com.github.ybq.android.spinkit.style.FoldingCube;
+import com.github.ybq.android.spinkit.style.Pulse;
+import com.github.ybq.android.spinkit.style.RotatingPlane;
+import com.github.ybq.android.spinkit.style.ThreeBounce;
+import com.github.ybq.android.spinkit.style.WanderingCubes;
+import com.github.ybq.android.spinkit.style.Wave;
+
+/**
+ * Created by wkh237 on 2016/11/6.
+ */
+
+public class RNSpinkitView extends SpinKitView{
+
+    private int mColor;
+    private Sprite mSprite = getSprite("");
+    private String mType;
+    private double mSize;
+
+    public RNSpinkitView(Context context) {
+        super(context);
+    }
+
+    public void setSpriteColor(String color) {
+        try {
+            mColor = Color.parseColor(color);
+            this.mSprite.setColor(mColor);
+            this.setIndeterminateDrawable(mSprite);
+        } catch(Exception err) {
+            Log.e("RNSpinkit-Err", err.toString() + "when set prop color to " + color);
+        }
+    }
+
+    public void setSpriteType(String type){
+        mType = type;
+        mSprite = this.getSprite(type);
+        mSprite.setColor(mColor);
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        this.setLayoutParams(params);
+        this.setIndeterminateDrawable(mSprite);
+    }
+
+    private Sprite getSprite(String spinnerType) {
+        switch (spinnerType) {
+            case "Bounce" :
+                return new DoubleBounce();
+            case "Wave" :
+                return new Wave();
+            case "RotatingPlane" :
+                return new RotatingPlane();
+            case "WanderingCubes":
+                return new WanderingCubes();
+            case "9CubeGrid":
+                return new CubeGrid();
+            case "FadingCircleAlt" :
+                return new FadingCircle();
+            case "Pulse" :
+                return new Pulse();
+            case "ChasingDots":
+                // Add scale factor to prevent clipping
+                Sprite d = new ChasingDots();
+                d.setScale(0.85f);
+                return d;
+            case "ThreeBounce":
+                return new ThreeBounce();
+            case "Circle":
+                return new Circle();
+            case "FoldingCube":
+                // Add scale factor to prevent clipping
+                Sprite sprite = new FoldingCube();
+                sprite.setScale(0.70f);
+                return sprite;
+            default :
+                break;
+        }
+        return new RotatingPlane();
+    }
+
+
+    public void setSpriteSize(double size) {
+        mSize = size;
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        this.setLayoutParams(params);
+    }
+}

--- a/scripts/rnpm-prelink.js
+++ b/scripts/rnpm-prelink.js
@@ -47,38 +47,3 @@ if (String(dep).match(/url[^h]*https\:\/\/jitpack\.io/) === null) {
   depStr = String(cfg).replace(/allprojects(.|[\r\n])+/, str);
   fs.writeFileSync(GRADLE_SCRIPT_PATH, depStr);
 }
-
-// check if RN version >= 0.29 and add project dependency to MainApplication.java
-
-var PACKAGE_JSON = process.cwd() + '/package.json';
-var hasNecessaryFile = fs.existsSync(PACKAGE_JSON);
-
-if (!hasNecessaryFile) {
-  throw 'RNSpinkit could not link Android automatically, some files could not be found.'
-}
-
-var package = JSON.parse(fs.readFileSync(PACKAGE_JSON));
-var APP_NAME = package.name;
-var APPLICATION_MAIN = process.cwd() + '/android/app/src/main/java/com/' + APP_NAME.toLocaleLowerCase() + '/MainApplication.java';
-
-console.log('RNSpinkit checking app version ..');
-
-var APP_VERSION = parseFloat(/\d\.\d+(?=\.)/.exec(package.dependencies['react-native']));
-
-if(APP_VERSION >= 0.29) {
-  console.log('RNSpinkit patching MainApplication.java .. ');
-  if(!fs.existsSync(APPLICATION_MAIN)) {
-    throw 'RNSpinkit could not link Android automatically, MainApplication.java not found in path : ' + APPLICATION_MAIN
-  }
-  var main = fs.readFileSync(APPLICATION_MAIN);
-  if(String(main).match('new RNSpinkitPackage()') !== null) {
-    console.log('skipped');
-    return
-  }
-  main = String(main).replace('new MainReactPackage()', 'new RNSpinkitPackage(),\n           new MainReactPackage()');
-  main = String(main).replace('import com.facebook.react.ReactApplication;', 'import com.facebook.react.ReactApplication;\nimport com.react.rnspinkit.RNSpinkitPackage;')
-
-  fs.writeFileSync(APPLICATION_MAIN, main);
-  console.log('RNSpinkit patching MainApplication.java .. ok')
-
-}


### PR DESCRIPTION
Hi @maxs15 , I'm sorry that took so long, I'm quite busy in these days. 

This PR contains 2 changes : 

1. React Native has merged `rnpm` into itself in 0.29, as such projects > 0.29 should use `react-native link` instead of `rnpm link` to properly link the library. I've also changed the instructions in README.md, please help improve it if needed.

2. Fix the issue #31 , the Android native implementation has changed, it should work properly now.

![spinners](https://cloud.githubusercontent.com/assets/5063785/20035759/25de39d2-a42c-11e6-88cd-166799e452c9.gif)
