### PR TITLE
Update iOS header imports for RN 0.40

### DIFF
--- a/ios/RNSpinkit.m
+++ b/ios/RNSpinkit.m
@@ -1,7 +1,7 @@
 #import "RNSpinkit.h"
-#import "RCTConvert.h"
-#import "RCTBridgeModule.h"
-#import "UIView+React.h"
+#import <React/RCTConvert.h>
+#import <React/RCTBridgeModule.h>
+#import <React/UIView+React.h>
 
 @implementation RNSpinkit
 {

--- a/ios/RNSpinkitManager.m
+++ b/ios/RNSpinkitManager.m
@@ -1,6 +1,6 @@
 #import "RNSpinkitManager.h"
 #import "RNSpinkit.h"
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 
 @implementation RNSpinkitManager
 


### PR DESCRIPTION
React Native 0.40 changes the way its iOS headers should be imported.