### PR TITLE
Removing allowBackup from AndroidManifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     package="com.react.rnspinkit">
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
 


### PR DESCRIPTION
Having `android:allowBackup="true"` in the AndroidManifest.xml of react-native-spinkit/android  causes build failure in the main app where this plugin is being used if android:allowBackup is set to false in the AndroidManifest of the main app. 

```bash
...
app:mergeReleaseStagingShaders UP-TO-DATE
:app:compileReleaseStagingShaders UP-TO-DATE
:app:generateReleaseStagingAssets UP-TO-DATE
:app:mergeReleaseStagingAssets UP-TO-DATE
:app:processReleaseStagingManifest
/Users/issa/projects/mobile/LoanApp/android/app/src/main/AndroidManifest.xml:22:7-34 Error:
        Attribute application@allowBackup value=(false) from AndroidManifest.xml:22:7-34
        is also present at [LoanApp:react-native-spinkit:unspecified] AndroidManifest.xml:12:9-35 value=(true).
        Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:20:5-43:19 to override.
```

While technically this can be solved by adding `tools:replace="android:allowBackup"` in the `<application />` of the main app, but for some reason, perhaps it's the SDK, my tool:replace didn't override the spinkit. Thus, removing it seems sensible in any case because I can't see a reason for it to be present in AndroidManifest of spinkit.

Please consider merging.