### PR TITLE
Allow props.children for iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,10 @@ class Spinkit extends React.Component {
 				type={String(this.props.type)}
 				size={parseInt(this.props.size)}
 				color={colorNumber}
-				style={[size, this.props.style]}/>
+				style={[size, this.props.style]}
+			>
+          {this.props.children}
+			</RNSpinkit>
 		);
 	}
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var {
 	NativeModules,
 	processColor,
 	requireNativeComponent,
-	View
+	View,
+	Platform
 } = ReactNative;
 
 var RNSpinkit = null;
@@ -41,6 +42,12 @@ class Spinkit extends React.Component {
 		isVisible: true
 	};
 
+	renderChildren() {
+		if(Platform.OS !== 'android') {
+			return (this.props.children);
+		}
+	}
+
 	render() {
 		if (!this.props.isVisible) return <View/>;
 
@@ -60,7 +67,7 @@ class Spinkit extends React.Component {
 				color={colorNumber}
 				style={[size, this.props.style]}
 			>
-          {this.props.children}
+			 {this.renderChildren()}
 			</RNSpinkit>
 		);
 	}


### PR DESCRIPTION
I have been testing having nested components for the iOS version for quite awhile now, and havn't encountered any problems - so perhaps allow this upstream?

It does not work on Android through, which is why I've added the platform check.