### PR TITLE
Remove <application> from AndroidManifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,10 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.react.rnspinkit">
-
-    <application
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
`<application>` in description makes harder to customize it for application. I.e. we are using [react-native-config](https://github.com/luggit/react-native-config) to store all values in one `.env` file and we customize application name with ENV-variable called `DISPLAY_NAME`. For this we use next code in AndroidManifest.yml:

```
<application
      android:name=".MainApplication"
      android:label="@string/DISPLAY_NAME"
      ...
```

In this case there is a conflict with AndroidManifest.yml from react-native-spinkit package, because `android:label` is different in main manifest and local package manifest.

Would be better to remove this tag from AndroidManifest.yml in your package and add wiki instruction to add `android:supportsRtl="true"` in main AndroidManifest.yml.