### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,23 +9,26 @@ repositories {
 
 buildscript {
     repositories {
+        google()
         mavenCentral()
         maven {
             url "https://jitpack.io"
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 
+def _ext = rootProject.ext; 
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 26;
+    buildToolsVersion _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '26.0.1';
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 26;
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
As [react-native 0.57](https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md#057) already uses newer versions of compileSdkVersion, targetSdkVersion and support library. I think it's time to update these values.

I've made it to allow any user to provide their own. I've made default versions 26 but I can make it the version you prefer.