### PR TITLE
Android gradle fixes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,3 @@
-apply plugin: 'com.android.library'
-
-repositories {
-    mavenCentral()
-    maven {
-        url "https://jitpack.io"
-    }
-}
-
 buildscript {
     repositories {
         mavenCentral()
@@ -15,30 +6,119 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        // Matches the RN Hello World template
+        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L8
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
+
+apply plugin: 'com.android.library'
+apply plugin: 'maven'
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+def DEFAULT_COMPILE_SDK_VERSION = 27
+def DEFAULT_BUILD_TOOLS_VERSION = "27.0.3"
+def DEFAULT_MIN_SDK_VERSION = 16
+def DEFAULT_TARGET_SDK_VERSION = 27
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+  compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
+  buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
 
-    defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
-        versionCode 1
-        versionName "1.0"
+  defaultConfig {
+    minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+    targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
+    versionCode 1
+    versionName "1.0"
+  }
+
+  lintOptions {
+    abortOnError false
+  }
+
+  buildTypes {
+    release {
+      minifyEnabled false
+      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
+  }
 }
 
+repositories {
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        // Matches the RN Hello World template
+        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L21
+        url "$projectDir/../node_modules/react-native/android"
+    }
+    mavenCentral()
+}
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.github.ybq:Android-SpinKit:1.1.0'
+}
+
+def configureReactNativePom(def pom) {
+    def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
+    pom.project {
+        name packageJson.title
+        artifactId packageJson.name
+        version = packageJson.version
+        group = "${packageIdentifier}"
+        description packageJson.description
+        url packageJson.repository.baseUrl
+        licenses {
+            license {
+                name packageJson.license
+                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
+                distribution 'repo'
+            }
+        }
+        developers {
+            developer {
+                id packageJson.author.username
+                name packageJson.author.name
+            }
+        }
+    }
+}
+
+afterEvaluate { project ->
+    task androidJavadoc(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += files(android.bootClasspath)
+        classpath += files(project.getConfigurations().getByName('compile').asList())
+        include '**/*.java'
+    }
+    task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
+        classifier = 'javadoc'
+        from androidJavadoc.destinationDir
+    }
+    task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.srcDirs
+        include '**/*.java'
+    }
+    android.libraryVariants.all { variant ->
+        def name = variant.name.capitalize()
+        task "jar$\{name\}"(type: Jar, dependsOn: variant.javaCompile) {
+            from variant.javaCompile.destinationDir
+        }
+    }
+    artifacts {
+        archives androidSourcesJar
+        archives androidJavadocJar
+    }
+    task installArchives(type: Upload) {
+        configuration = configurations.archives
+        repositories.mavenDeployer {
+            // Deploy to react-native-event-bridge/maven, ready to publish to npm
+            repository url: "file://$\{projectDir\}/../android/maven"
+            configureReactNativePom pom
+        }
+    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
 def configureReactNativePom(def pom) {
     def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
+
     pom.project {
         name packageJson.title
         artifactId packageJson.name
@@ -71,6 +72,7 @@ def configureReactNativePom(def pom) {
         group = "${packageIdentifier}"
         description packageJson.description
         url packageJson.repository.baseUrl
+
         licenses {
             license {
                 name packageJson.license
@@ -78,6 +80,7 @@ def configureReactNativePom(def pom) {
                 distribution 'repo'
             }
         }
+
         developers {
             developer {
                 id packageJson.author.username
@@ -88,36 +91,43 @@ def configureReactNativePom(def pom) {
 }
 
 afterEvaluate { project ->
+
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
         classpath += files(project.getConfigurations().getByName('compile').asList())
         include '**/*.java'
     }
+
     task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
         classifier = 'javadoc'
         from androidJavadoc.destinationDir
     }
+
     task androidSourcesJar(type: Jar) {
         classifier = 'sources'
         from android.sourceSets.main.java.srcDirs
         include '**/*.java'
     }
+
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task "jar$\{name\}"(type: Jar, dependsOn: variant.javaCompile) {
+        task "jar${name}"(type: Jar, dependsOn: variant.javaCompile) {
             from variant.javaCompile.destinationDir
         }
     }
+
     artifacts {
         archives androidSourcesJar
         archives androidJavadocJar
     }
+
     task installArchives(type: Upload) {
         configuration = configurations.archives
         repositories.mavenDeployer {
             // Deploy to react-native-event-bridge/maven, ready to publish to npm
-            repository url: "file://$\{projectDir\}/../android/maven"
+            repository url: "file://${projectDir}/../android/maven"
+
             configureReactNativePom pom
         }
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        jcenter()
         mavenCentral()
         maven {
             url "https://jitpack.io"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,7 +70,7 @@ def configureReactNativePom(def pom) {
         name packageJson.title
         artifactId packageJson.name
         version = packageJson.version
-        group = "${packageIdentifier}"
+        group = "com.react.rnspinkit"
         description packageJson.description
         url packageJson.repository.baseUrl
 


### PR DESCRIPTION
I've used `react-native-create-library` to rebuild the build.gradle file, this is an alternative pull request for #101.

This should be backwards compatible, as well as compatible with newer versions of React Native. It delegates SDK versions to the parent project which imports this library, rather than hard-coding them.