### PR TITLE
 Add the sageExtGet function to adapt custom version of buildTools, compileSdk and targetSdk

### DIFF
--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -90,13 +90,13 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+     compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example"
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         ndk {
@@ -135,7 +135,7 @@ android {
 dependencies {
     compile project(':react-native-spinkit')
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     compile "com.facebook.react:react-native:+"  // From node_modules
 }
 

--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-     ext {
+    ext {
         buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28
@@ -10,6 +10,10 @@ buildscript {
     }
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -21,10 +25,14 @@ buildscript {
 
 allprojects {
     repositories {
-				// Add jitpack repository (added by react-native-spinkit)
-				maven { url "https://jitpack.io" }
+        // Add jitpack repository (added by react-native-spinkit)
+        maven { url "https://jitpack.io" }
         mavenLocal()
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"

--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -1,6 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+     ext {
+        buildToolsVersion = "28.0.3"
+        minSdkVersion = 16
+        compileSdkVersion = 28
+        targetSdkVersion = 27
+        supportLibVersion = "28.0.0"
+    }
     repositories {
         jcenter()
     }

--- a/Example/android/settings.gradle
+++ b/Example/android/settings.gradle
@@ -2,4 +2,4 @@ rootProject.name = 'Example'
 
 include ':app'
 include ':react-native-spinkit'
-project(':react-native-spinkit').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-spinkit/android')
+project(':react-native-spinkit').projectDir = new File(rootProject.projectDir, '../../android')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,5 +44,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.github.ybq:Android-SpinKit:1.1.0'
+    compile 'com.github.ybq:Android-SpinKit:1.2.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 repositories {
     mavenCentral()
     maven {
@@ -20,12 +24,12 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion  safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion  safeExtGet('buildToolsVersion', "23.0.1")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion  safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 23)
         versionCode 1
         versionName "1.0"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,5 +44,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.github.ybq:Android-SpinKit:1.2.0'
+    compile 'com.github.ybq:Android-SpinKit:1.1.0'
 }


### PR DESCRIPTION

Add the sageExtGet function to adapt custom version of buildTools, compileSdk and targetSdk