### PR TITLE
Switch 'compile' to 'implementation'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,6 @@ android {
 
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.github.ybq:Android-SpinKit:1.2.0'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.github.ybq:Android-SpinKit:1.2.0'
 }


### PR DESCRIPTION
This is a fix for the warning message shown when syncing
Gradle. The warning is:

WARNING: Configuration 'compile' is obsolete and has been
replaced with 'implementation' and 'api'. It will be removed
at the end of 2018.

See: https://github.com/maxs15/react-native-spinkit/issues/119