### PR TITLE
Remove rnpm and add react-native config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,6 @@
     "email": "maxime.mezrahi@gmail.com",
     "url": "https://github.com/maxs15"
   },
-  "rnpm": {
-		"commands": {
-			"prelink": "node ./node_modules/react-native-spinkit/scripts/rnpm-prelink.js"
-		}
-	},
   "dependencies": {
     "prop-types": "^15.5.8"
   }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  commands: {
+    prelink: "node ./node_modules/react-native-spinkit/scripts/rnpm-prelink.js",
+  },
+};


### PR DESCRIPTION
When I  build my app using this dependence the CLI return me this warning:
```The following packages use deprecated "rnpm" config that will stop working from next release:  react-native-spinkit: https://npmjs.com/package/react-native-spinkit```

Please notify their maintainers about it. You can find more details at https://react-native-community/cli/docs/configuration.md#migration-guide.

This PR it`s basically this update