### PR TITLE
RN0.60.0 and Android 9 support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,6 @@ android {
 
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.github.ybq:Android-SpinKit:1.2.0'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.github.ybq:Android-SpinKit:1.2.0'
 }


### PR DESCRIPTION
`compileOnly` should be replaced with `implementation`. Otherwise its not building