### PR TITLE
Update for latest React Native, Spinkit Android dependency and TS support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,9 +5,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven {
-            url "https://jitpack.io"
-        }
     }
 
     dependencies {
@@ -40,6 +37,9 @@ repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$rootDir/../node_modules/react-native/android"
+    }
+    maven {
+        url "https://jitpack.io"
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,135 +1,50 @@
 buildscript {
+    ext.safeExtGet = {prop, fallback ->
+        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
     repositories {
+        google()
         jcenter()
-        mavenCentral()
         maven {
             url "https://jitpack.io"
         }
     }
+
     dependencies {
-        // Matches the RN Hello World template
-        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L8
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        //noinspection GradleDependency
+        classpath("com.android.tools.build:gradle:${safeExtGet('gradlePluginVersion', '3.4.1')}")
     }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
-
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-}
-
-def DEFAULT_COMPILE_SDK_VERSION = 27
-def DEFAULT_BUILD_TOOLS_VERSION = "27.0.3"
-def DEFAULT_MIN_SDK_VERSION = 16
-def DEFAULT_TARGET_SDK_VERSION = 27
 
 android {
-  compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
-  buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    //noinspection GradleDependency
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
-  defaultConfig {
-    minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
-    targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
-    versionCode 1
-    versionName "1.0"
-  }
-
-  lintOptions {
-    abortOnError false
-  }
-
-  buildTypes {
-    release {
-      minifyEnabled false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+    defaultConfig {
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        //noinspection OldTargetApi
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
     }
-  }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 repositories {
+    mavenLocal()
+    google()
+    jcenter()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches the RN Hello World template
-        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L21
-        url "$projectDir/../node_modules/react-native/android"
+        url "$rootDir/../node_modules/react-native/android"
     }
-    mavenCentral()
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:${safeExtGet('reactnativeVersion', '+')}"
     implementation 'com.github.ybq:Android-SpinKit:1.4.0'
-}
-
-def configureReactNativePom(def pom) {
-    def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
-
-    pom.project {
-        name packageJson.title
-        artifactId packageJson.name
-        version = packageJson.version
-        group = "com.react.rnspinkit"
-        description packageJson.description
-        url packageJson.repository.baseUrl
-
-        licenses {
-            license {
-                name packageJson.license
-                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
-                distribution 'repo'
-            }
-        }
-
-        developers {
-            developer {
-                id packageJson.author.username
-                name packageJson.author.name
-            }
-        }
-    }
-}
-
-afterEvaluate { project ->
-
-    task androidJavadoc(type: Javadoc) {
-        source = android.sourceSets.main.java.srcDirs
-        classpath += files(android.bootClasspath)
-        classpath += files(project.getConfigurations().getByName('compile').asList())
-        include '**/*.java'
-    }
-
-    task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
-        classifier = 'javadoc'
-        from androidJavadoc.destinationDir
-    }
-
-    task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
-        from android.sourceSets.main.java.srcDirs
-        include '**/*.java'
-    }
-
-    android.libraryVariants.all { variant ->
-        def name = variant.name.capitalize()
-        task "jar${name}"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
-        }
-    }
-
-    artifacts {
-        archives androidSourcesJar
-        archives androidJavadocJar
-    }
-
-    task installArchives(type: Upload) {
-        configuration = configurations.archives
-        repositories.mavenDeployer {
-            // Deploy to react-native-event-bridge/maven, ready to publish to npm
-            repository url: "file://${projectDir}/../android/maven"
-
-            configureReactNativePom pom
-        }
-    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,7 +60,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.ybq:Android-SpinKit:1.2.0'
+    implementation 'com.github.ybq:Android-SpinKit:1.4.0'
 }
 
 def configureReactNativePom(def pom) {

--- a/android/src/main/java/com/react/rnspinkit/RNSpinkit.java
+++ b/android/src/main/java/com/react/rnspinkit/RNSpinkit.java
@@ -2,7 +2,7 @@ package com.react.rnspinkit;
 
 
 import android.graphics.Color;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,30 @@
+declare module 'react-native-spinkit' {
+    import React from 'react';
+
+    export type SpinnerType =
+      | 'CircleFlip'
+      | 'Bounce'
+      | 'Wave'
+      | 'WanderingCubes'
+      | 'Pulse'
+      | 'ChasingDots'
+      | 'ThreeBounce'
+      | 'Circle'
+      | '9CubeGrid'
+      | 'WordPress'
+      | 'FadingCircle'
+      | 'FadingCircleAlt'
+      | 'Arc'
+      | 'ArcAlt'
+      | 'Plane';
+
+    export type SpinnerProps = {
+      isVisible?: boolean;
+      color?: string;
+      size?: number;
+      type?: SpinnerType;
+    };
+
+    const Spinner: React.ComponentType<SpinnerProps>;
+    export default Spinner;
+  }

--- a/react-native-spinkit.podspec
+++ b/react-native-spinkit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "react-native-spinkit"
-  s.version      = "1.0.2"
+  s.version      = package['version']
   s.license      = "MIT"
   s.homepage     = "https://github.com/maxs15/react-native-spinkit"
   s.authors      = { 'Maxime Mezrahi' => 'maximemezrahi@gmail.com' }

--- a/react-native-spinkit.podspec
+++ b/react-native-spinkit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "react-native-spinkit"
-  s.version      = package['version']
+  s.version      = "1.4.1"
   s.license      = "MIT"
   s.homepage     = "https://github.com/maxs15/react-native-spinkit"
   s.authors      = { 'Maxime Mezrahi' => 'maximemezrahi@gmail.com' }


### PR DESCRIPTION
I combined all the fixes and upgraded Spinkit if someones interested. Everything seems to work as on React Native 0.60.6 on iOS & Android. Also integrated TS types thanks to @nartc @steffenagger
fixes #105, fixes #126, fixes #119, fixies #96, fixes  #106
PRs that do similar things: closes #128, closes #127, closes #103, closes #101 
You can use my fork if this does not get merged.