### PR TITLE
Document style prop in TS definition and React proptypes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 declare module 'react-native-spinkit' {
     import React from 'react';
+    import { StyleProp, ViewStyle } from "react-native";
 
     export type SpinnerType =
       | 'CircleFlip'
@@ -23,6 +24,7 @@ declare module 'react-native-spinkit' {
       color?: string;
       size?: number;
       type?: SpinnerType;
+      style?: StyleProp<ViewStyle>;
     };
 
     const Spinner: React.ComponentType<SpinnerProps>;

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ class Spinkit extends React.Component {
 		renderToHardwareTextureAndroid: PropTypes.bool,
 		importantForAccessibility: PropTypes.string,
 		onLayout: PropTypes.func,
+		style: PropTypes.object,
 	};
 
 	static defaultProps = {


### PR DESCRIPTION
Looks like there's an undocumented style prop that can be passed to the Spinkit component. This PR updates the component's TS and proptype definitions.