### PR TITLE
fix: 🐛Warning: Failed prop type: Invalid prop `style` of type `array` supplied to `Spinkit`, expected `object`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var {
 	NativeModules,
 	processColor,
 	requireNativeComponent,
-	View
+	View,
+	ViewPropTypes
 } = ReactNative;
 
 var RNSpinkit = null;
@@ -33,7 +34,7 @@ class Spinkit extends React.Component {
 		renderToHardwareTextureAndroid: PropTypes.bool,
 		importantForAccessibility: PropTypes.string,
 		onLayout: PropTypes.func,
-		style: PropTypes.object,
+		style: ViewPropTypes.style,
 	};
 
 	static defaultProps = {


### PR DESCRIPTION
There will be this warning after upgrading the version, which is not a good behavior